### PR TITLE
Add template helpers for propagating variable files

### DIFF
--- a/helper.tf
+++ b/helper.tf
@@ -1,0 +1,82 @@
+locals {
+  tfvars_platform = templatefile("${path.module}/templates/platform.tfvars.hcl", {
+    prefix               = var.prefix
+    external_domain      = var.external_domain
+    use_le_staging       = var.use_le_staging
+    resource_group_name  = var.resource_group_name
+    storage_account_name = var.storage_account_name
+    client_id            = var.client_id
+    client_secret        = var.client_secret
+    tenant_id            = var.tenant_id
+    subscription_id      = var.subscription_id
+  })
+  backend_tf_platform = templatefile("${path.module}/templates/backend.hcl", {
+    key                  = "platform"
+    resource_group_name  = var.resource_group_name
+    storage_account_name = var.storage_account_name
+    client_id            = var.client_id
+    client_secret        = var.client_secret
+    tenant_id            = var.tenant_id
+    subscription_id      = var.subscription_id
+  })
+
+  tfvars_appsupport = templatefile("${path.module}/templates/appsupport.tfvars.hcl", {
+    prefix            = var.prefix
+    external_domain   = var.external_domain
+    use_le_staging    = var.use_le_staging
+    dc_name           = var.dc_name
+    jenkins_volume_id = var.azure_csi ? azurerm_managed_disk.jenkins[0].id : ""
+  })
+  backend_tf_appsupport = templatefile("${path.module}/templates/backend.hcl", {
+    key                  = "appsupport"
+    resource_group_name  = var.resource_group_name
+    storage_account_name = var.storage_account_name
+    client_id            = var.client_id
+    client_secret        = var.client_secret
+    tenant_id            = var.tenant_id
+    subscription_id      = var.subscription_id
+  })
+
+  tfvars_workload = templatefile("${path.module}/templates/workload.tfvars.hcl", {
+    prefix          = var.prefix
+    external_domain = var.external_domain
+    use_le_staging  = var.use_le_staging
+    dc_name         = var.dc_name
+  })
+  backend_tf_workload = templatefile("${path.module}/templates/backend.hcl", {
+    key                  = "workload"
+    resource_group_name  = var.resource_group_name
+    storage_account_name = var.storage_account_name
+    client_id            = var.client_id
+    client_secret        = var.client_secret
+    tenant_id            = var.tenant_id
+    subscription_id      = var.subscription_id
+  })
+}
+
+resource "local_file" "tfvars_platform" {
+  filename = "${path.module}/../caravan-platform/${var.prefix}-azure.tfvars"
+  content  = local.tfvars_platform
+}
+resource "local_file" "backend_tf_platform" {
+  filename = "${path.module}/../caravan-platform/${var.prefix}-azure-backend.tf"
+  content  = local.backend_tf_platform
+}
+
+resource "local_file" "tfvars_appsupport" {
+  filename = "${path.module}/../caravan-application-support/${var.prefix}-azure.tfvars"
+  content  = local.tfvars_appsupport
+}
+resource "local_file" "backend_tf_appsupport" {
+  filename = "${path.module}/../caravan-application-support/${var.prefix}-azure-backend.tf"
+  content  = local.backend_tf_appsupport
+}
+
+resource "local_file" "tfvars_workload" {
+  filename = "${path.module}/../caravan-workload/${var.prefix}-azure.tfvars"
+  content  = local.tfvars_workload
+}
+resource "local_file" "backend_tf_workload" {
+  filename = "${path.module}/../caravan-workload/${var.prefix}-azure-backend.tf"
+  content  = local.backend_tf_workload
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,3 +29,27 @@ output "subscription_id" {
 output "vault_resource_name" {
   value = var.vault_auth_resource
 }
+
+output "platform_tfvars" {
+  value = local.tfvars_platform
+}
+
+output "platform_backend" {
+  value = local.backend_tf_platform
+}
+
+output "appsupport_tfvars" {
+  value = local.tfvars_appsupport
+}
+
+output "appsupport_backend" {
+  value = local.backend_tf_appsupport
+}
+
+output "workload_tfvars" {
+  value = local.tfvars_workload
+}
+
+output "workload_backend" {
+  value = local.backend_tf_workload
+}

--- a/templates/appsupport.tfvars.hcl
+++ b/templates/appsupport.tfvars.hcl
@@ -1,0 +1,23 @@
+
+vault_endpoint  = "https://vault.${prefix}.${external_domain}"
+consul_endpoint = "https://consul.${prefix}.${external_domain}"
+nomad_endpoint  = "https://nomad.${prefix}.${external_domain}"
+domain          = "${external_domain}"
+
+%{ if use_le_staging ~}
+vault_skip_tls_verify = true
+consul_insecure_https = true
+ca_cert_file          = "../caravan-infra-azure/ca_certs.pem"
+configure_grafana = false
+%{ else ~}
+vault_skip_tls_verify = false
+consul_insecure_https = false
+configure_grafana     = true
+%{ endif ~}
+
+services_domain            = "service.consul"
+dc_names                   = ["${dc_name}"]
+cloud                      = "azure"
+artifacts_source_prefix    = ""
+jenkins_volume_external_id = "${jenkins_volume_id}"
+container_registry         = ""

--- a/templates/backend.hcl
+++ b/templates/backend.hcl
@@ -1,0 +1,13 @@
+
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "${resource_group_name}"
+    storage_account_name = "${storage_account_name}"
+    container_name       = "tfstate"
+    key                  = "${key}/terraform/state/terraform.tfstate"
+    client_id            = "${client_id}"
+    client_secret        = "${client_secret}"
+    tenant_id            = "${tenant_id}"
+    subscription_id      = "${subscription_id}"
+  }
+}

--- a/templates/platform.tfvars.hcl
+++ b/templates/platform.tfvars.hcl
@@ -1,0 +1,24 @@
+
+vault_endpoint  = "https://vault.${prefix}.${external_domain}"
+consul_endpoint = "https://consul.${prefix}.${external_domain}"
+nomad_endpoint  = "https://nomad.${prefix}.${external_domain}"
+
+%{ if use_le_staging ~}
+vault_skip_tls_verify = true
+consul_insecure_https = true
+ca_cert_file          = "../caravan-infra-azure/ca_certs.pem"
+%{ else ~}
+vault_skip_tls_verify = false
+consul_insecure_https = false
+%{ endif ~}
+
+bootstrap_state_backend_provider   = "azure"
+auth_providers                     = ["azure"]
+bootstrap_state_object_name_prefix = "infraboot/terraform/state"
+
+azure_bootstrap_resource_group_name  = "${resource_group_name}"
+azure_bootstrap_storage_account_name = "${storage_account_name}"
+azure_bootstrap_client_id            = "${client_id}"
+azure_bootstrap_client_secret        = "${client_secret}"
+azure_bootstrap_tenant_id            = "${tenant_id}"
+azure_bootstrap_subscription_id      = "${subscription_id}"

--- a/templates/workload.tfvars.hcl
+++ b/templates/workload.tfvars.hcl
@@ -1,0 +1,20 @@
+
+vault_endpoint  = "https://vault.${prefix}.${external_domain}"
+consul_endpoint = "https://consul.${prefix}.${external_domain}"
+nomad_endpoint  = "https://nomad.${prefix}.${external_domain}"
+domain          = "${external_domain}"
+
+%{ if use_le_staging ~}
+vault_skip_tls_verify = true
+consul_insecure_https = true
+ca_cert_file          = "../caravan-infra-azure/ca_certs.pem"
+%{ else ~}
+vault_skip_tls_verify = false
+consul_insecure_https = false
+%{ endif ~}
+
+artifacts_source_prefix = ""
+services_domain         = "service.consul"
+dc_names                = ["${dc_name}"]
+github_shared_secret    = ""
+github_token            = ""


### PR DESCRIPTION
This is an evaluation of creating `backend.tf` and `azure.tfvars` automatically for post infra terraform projects like platform, appsupport and workload