### PR TITLE
fix: refactor disk creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ terraform apply -var-file azure.tfvars
 | [azurerm_client_config](https://registry.terraform.io/providers/hashicorp/azurerm/2.46.1/docs/data-sources/client_config) |
 | [azurerm_dns_a_record](https://registry.terraform.io/providers/hashicorp/azurerm/2.46.1/docs/resources/dns_a_record) |
 | [azurerm_dns_ns_record](https://registry.terraform.io/providers/hashicorp/azurerm/2.46.1/docs/resources/dns_ns_record) |
-| [azurerm_dns_zone](https://registry.terraform.io/providers/hashicorp/azurerm/2.46.1/docs/resources/dns_zone) |
 | [azurerm_dns_zone](https://registry.terraform.io/providers/hashicorp/azurerm/2.46.1/docs/data-sources/dns_zone) |
+| [azurerm_dns_zone](https://registry.terraform.io/providers/hashicorp/azurerm/2.46.1/docs/resources/dns_zone) |
 | [azurerm_image](https://registry.terraform.io/providers/hashicorp/azurerm/2.46.1/docs/data-sources/image) |
 | [azurerm_key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/2.46.1/docs/resources/key_vault) |
 | [azurerm_key_vault_access_policy](https://registry.terraform.io/providers/hashicorp/azurerm/2.46.1/docs/resources/key_vault_access_policy) |
@@ -95,13 +95,13 @@ terraform apply -var-file azure.tfvars
 |------|-------------|------|---------|:--------:|
 | allowed\_ssh\_cidrs | The list of CIDRs from which ssh is allowed. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | app\_gateway\_subnet\_cidr | The CIDR of the subnet created for the Application Gateway instance. | `string` | `"10.0.2.0/24"` | no |
-| azure\_csi | Wheter to create an Azure Disk for Nomad Volume CSI testing. | `bool` | `true` | no |
 | ca\_certs | A group of certificate objects to download locally. This helps when using Let's Encrypt staging environment. | <pre>map(object({<br>    filename = string<br>    pemurl   = string<br>  }))</pre> | <pre>{<br>  "fakeleintermediatex1": {<br>    "filename": "fakeleintermediatex1.pem",<br>    "pemurl": "https://letsencrypt.org/certs/fakeleintermediatex1.pem"<br>  },<br>  "fakelerootx1": {<br>    "filename": "fakelerootx1.pem",<br>    "pemurl": "https://letsencrypt.org/certs/fakelerootx1.pem"<br>  }<br>}</pre> | no |
 | client\_id | The Azure Service Principal Client ID which should be used. | `string` | n/a | yes |
 | client\_secret | The Azure Service Principal Client Secret which should be used. | `string` | n/a | yes |
 | control\_plane\_disk\_size | The size of control plane instances disk. | `string` | `"40"` | no |
 | control\_plane\_instance\_count | The number of control plane instances. | `number` | `3` | no |
 | control\_plane\_size | The size of control plane instances. | `string` | `"Standard_B2s"` | no |
+| csi\_volumes | Example:<br>{<br>  "jenkins" : {<br>    "storage\_account\_type" : "Standard\_LRS"<br>    "disk\_size\_gb" : "30"<br>  }<br>} | `map(map(string))` | `{}` | no |
 | dc\_name | The Consul DC name. | `string` | `"azure-dc"` | no |
 | enable\_monitoring | Whether to create an additional instance for monitoring purposes. | `bool` | `true` | no |
 | external\_domain | The external domain to use for registering DNS names. | `string` | n/a | yes |
@@ -132,6 +132,7 @@ terraform apply -var-file azure.tfvars
 | appsupport\_tfvars | n/a |
 | control\_plane\_role\_name | n/a |
 | control\_plane\_service\_principal\_ids | n/a |
+| csi\_volumes | n/a |
 | ips | n/a |
 | platform\_backend | n/a |
 | platform\_tfvars | n/a |

--- a/helper.tf
+++ b/helper.tf
@@ -25,7 +25,7 @@ locals {
     external_domain   = var.external_domain
     use_le_staging    = var.use_le_staging
     dc_name           = var.dc_name
-    jenkins_volume_id = var.azure_csi ? azurerm_managed_disk.jenkins[0].id : ""
+    jenkins_volume_id = lookup(local.volumes_name_to_id, "jenkins", "")
     tenant_id         = var.tenant_id
     subscription_id   = var.subscription_id
   })

--- a/outputs.tf
+++ b/outputs.tf
@@ -63,3 +63,7 @@ output "ips" {
     monitoring    = { for n in azurerm_linux_virtual_machine.monitoring : n.name => n.public_ip_address }
   }
 }
+
+output "csi_volumes" {
+  value = local.volumes_name_to_id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -145,11 +145,6 @@ variable "ca_certs" {
   }
   description = "A group of certificate objects to download locally. This helps when using Let's Encrypt staging environment."
 }
-variable "azure_csi" {
-  type        = bool
-  default     = true
-  description = "Wheter to create an Azure Disk for Nomad Volume CSI testing."
-}
 variable "image_resource_group_name" {
   type        = string
   description = "The Azure Resource Group name where Caravan images are available."
@@ -158,6 +153,19 @@ variable "vault_auth_resource" {
   type        = string
   default     = "https://management.azure.com/"
   description = "The Azure AD application to use for generating access tokens."
+}
+variable "csi_volumes" {
+  type        = map(map(string))
+  default     = {}
+  description = <<EOF
+Example:
+{
+  "jenkins" : {
+    "storage_account_type" : "Standard_LRS"
+    "disk_size_gb" : "30"
+  }
+}
+EOF
 }
 
 variable "tags" {

--- a/volumes.tf
+++ b/volumes.tf
@@ -1,12 +1,15 @@
-resource "azurerm_managed_disk" "jenkins" {
-  count = var.azure_csi ? 1 : 0
+resource "azurerm_managed_disk" "csi" {
+  for_each = var.csi_volumes
 
   create_option        = "Empty"
   location             = var.location
-  name                 = "${var.prefix}-jenkins"
+  name                 = each.key
   resource_group_name  = var.resource_group_name
-  storage_account_type = "Standard_LRS"
-  disk_size_gb         = 30
+  storage_account_type = lookup(each.value, "storage_account_type", "Standard_LRS")
+  disk_size_gb         = lookup(each.value, "disk_size_gb", 30)
+  tags                 = var.tags
+}
 
-  tags = var.tags
+locals {
+  volumes_name_to_id = { for v in azurerm_managed_disk.csi : v.name => v.id }
 }


### PR DESCRIPTION
closes #20﻿

We keep a reference to jenkins for appsupport layer, but we allow creation of different managed disks.
The one picked for jenkins appsupp is the one that is named "jenkins"